### PR TITLE
Change Package name and added ParseUUID function

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,4 +20,21 @@ func (t *Test) BeforeCreate(tx *gorm.DB) error {
 }
 ```
 
+
+### Usage
+
+##### Where statement:
+```go
+model := Test{}
+db.Find(&model, "id = ?", ParseUUID("ed67a4b2-8f77-4d18-8c58-0508e7b207e8"))
+log.Printf("data: %+v\n", model)
+```
+
+##### Create statement: 
+Will autogenerate uuid automatically because of `BeforeCreate` hook added
+```go
+data := Test{Name: fmt.Sprintf("Time is: %s", time.Now())}
+db.Create(&data)
+```
+
 **Check [this article](https://dipesh-kc.medium.com/implementation-of-uuid-and-binary-16-in-gorm-v2-1c329c352c91?sk=04dd6a121675ed4f2a635eabc3c3592b) for more information**

--- a/binary_uuid.go
+++ b/binary_uuid.go
@@ -11,6 +11,11 @@ import (
 // BinaryUUID -> binary uuid wrapper over uuid.UUID
 type BinaryUUID uuid.UUID
 
+// ParseUUID -> parses string uuid to binary uuid
+func ParseUUID(id string) BinaryUUID {
+	return BinaryUUID(uuid.MustParse(id))
+}
+
 func (b BinaryUUID) String() string {
 	return uuid.UUID(b).String()
 }

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,8 @@
-module github.com/dipeshdulal/gorm_uuid
+module github.com/dipeshdulal/binary-uuid-gorm
 
 go 1.15
 
 require (
-	github.com/docker/distribution v2.7.1+incompatible
 	github.com/google/uuid v1.1.2
 	gorm.io/driver/mysql v1.0.3
 	gorm.io/gorm v1.20.7

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/docker/distribution v2.7.1+incompatible h1:a5mlkVzth6W5A4fOsS3D2EO5BUmsJpcB+cRlLU7cSug=
-github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/go-sql-driver/mysql v1.5.0 h1:ozyZYNQW3x3HtqT1jira07DN2PArx2v7/mN66gGcHOs=
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"time"
 
 	"github.com/google/uuid"
 	_ "gorm.io/driver/mysql"
@@ -32,22 +33,24 @@ func main() {
 	db.AutoMigrate(&Test{})
 
 	createdData := createNewData(db)
-
 	log.Printf("Created Data: %+v \n", createdData)
 
+	// where statement by unmarshaling string to binary uuid
 	data := `{"id": "%s"}`
 	data = fmt.Sprintf(data, createdData.ID)
-
 	marshalData := Test{}
 	err = json.Unmarshal([]byte(data), &marshalData)
 	db.Where("id = ?", marshalData.ID).First(&marshalData)
-
 	log.Printf("Where query on data: %+v \n", marshalData)
 
+	// Where statement
+	model := Test{}
+	db.Find(&model, "id = ?", ParseUUID("ed67a4b2-8f77-4d18-8c58-0508e7b207e8"))
+	log.Printf("data: %+v\n", model)
 }
 
 func createNewData(db *gorm.DB) Test {
-	data := Test{Name: "New Data Goes Here!!"}
+	data := Test{Name: fmt.Sprintf("Time is: %s", time.Now())}
 	db.Create(&data)
 	return data
 }


### PR DESCRIPTION
#### What this pull request contains:
- ParseUUID function has been added.
```go
model := Test{}
db.Find(&model, "id = ?", ParseUUID("ed67a4b2-8f77-4d18-8c58-0508e7b207e8"))
log.Printf("data: %+v\n", model)
```
- Updated README with usage.
- Changed package name to `binary-uuid-gorm` same as git repository  name.